### PR TITLE
Is the typescale math off for h1-h3?

### DIFF
--- a/_config.scss
+++ b/_config.scss
@@ -15,9 +15,9 @@ $padding-count: 8; //Generates padding classes in 0.5rem increments
 $layout-count: 25; //Generates height/width classes in 0.5rem increments
 
 //Type Scale
-$h1: 1.5rem;    // 32px
-$h2: 1.25rem;   // 24px
-$h3: 1.125rem;  // 20px
+$h1: 2rem;    // 32px
+$h2: 1.5rem;   // 24px
+$h3: 1.25rem;  // 20px
 $h4: 1rem;      // 16px
 $h5: 0.875rem;  // 14px
 $h6: 0.75rem;   // 12px


### PR DESCRIPTION
Is the math off for the type sizes of h1-h3?
